### PR TITLE
Automatically handle kr vs global encryption

### DIFF
--- a/app/src/main/java/com/arsylk/mammonsmite/DestinyChild/DCTools.java
+++ b/app/src/main/java/com/arsylk/mammonsmite/DestinyChild/DCTools.java
@@ -12,6 +12,7 @@ import com.arsylk.mammonsmite.Async.interfaces.OnLocaleUnpackFinished;
 import com.arsylk.mammonsmite.Async.interfaces.OnPackFinishedListener;
 import com.arsylk.mammonsmite.Async.interfaces.OnUnpackFinishedListener;
 import com.arsylk.mammonsmite.Live2D.L2DModel;
+import com.arsylk.mammonsmite.activities.DCModelsActivity;
 import com.arsylk.mammonsmite.activities.L2DModelsActivity;
 import com.arsylk.mammonsmite.utils.Define;
 import com.arsylk.mammonsmite.utils.LoadAssets;
@@ -237,14 +238,19 @@ public class DCTools {
 
     //unpacking pck files
     public static void asyncUnpack(File src, Context context, OnUnpackFinishedListener onUnpackFinishedListener) {
-        new AsyncUnpack(context, true)
-                .setOnUnpackFinishedListener(onUnpackFinishedListener)
-                .execute(src);
-    }
-
-    public static void asyncUnpack(File src, int key, Context context, OnUnpackFinishedListener onUnpackFinishedListener) {
-        new AsyncUnpack(context, key, true)
-                .setOnUnpackFinishedListener(onUnpackFinishedListener)
+        new AsyncUnpack(context, 0,true) // try kr key first
+                .setOnUnpackFinishedListener(new OnUnpackFinishedListener() {
+                    @Override
+                    public void onFinished(DCModel dcModel) {
+                        if(dcModel != null) {
+                            onUnpackFinishedListener.onFinished(dcModel);
+                        }else {
+                            new AsyncUnpack(context, 1, true) // try global key if failed
+                                    .setOnUnpackFinishedListener(onUnpackFinishedListener)
+                                    .execute(src);
+                        }
+                    }
+                })
                 .execute(src);
     }
 

--- a/app/src/main/java/com/arsylk/mammonsmite/activities/DCModelsActivity.java
+++ b/app/src/main/java/com/arsylk/mammonsmite/activities/DCModelsActivity.java
@@ -72,29 +72,18 @@ public class DCModelsActivity extends ActivityWithExceptionRedirect {
         model_list.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, final int i, long l) {
-                List<PickWhichDialog.Option<Integer>> keyList = new ArrayList<>();
-                keyList.add(new PickWhichDialog.Option<>("Korea/Japan",0));
-                keyList.add(new PickWhichDialog.Option<>("Global",1));
-                new PickWhichDialog<>(context, keyList).setOnOptionPicked(new PickWhichDialog.Option.OnOptionPicked<Integer>() {
+                DCTools.asyncUnpack(adapter.getItem(i).getFile(), context, new OnUnpackFinishedListener() {
                     @Override
-                    public void onOptionPicked(PickWhichDialog.Option<Integer> option) {
-                        if(option != null){
-                            final int key = option.getObject();
-                            DCTools.asyncUnpack(adapter.getItem(i).getFile(), key, context, new OnUnpackFinishedListener() {
-                                @Override
-                                public void onFinished(DCModel dcModel) {
-                                    if(dcModel != null) {
-                                        if(dcModel.isLoaded()) {
-                                            DCModelsActivity.showPickAction(context, dcModel.asL2DModel());
-                                        }
-                                    }else {
-                                        Toast.makeText(context, "Failed to unpack!", Toast.LENGTH_SHORT).show();
-                                    }
-                                }
-                            });
+                    public void onFinished(DCModel dcModel) {
+                        if(dcModel != null) {
+                            if(dcModel.isLoaded()) {
+                                DCModelsActivity.showPickAction(context, dcModel.asL2DModel());
+                            }
+                        }else {
+                            Toast.makeText(context, "Failed to unpack!", Toast.LENGTH_SHORT).show();
                         }
                     }
-                }).show();
+                });
             }
         });
 

--- a/app/src/main/java/com/arsylk/mammonsmite/activities/MainActivity.java
+++ b/app/src/main/java/com/arsylk/mammonsmite/activities/MainActivity.java
@@ -71,29 +71,18 @@ public class MainActivity extends ActivityWithExceptionRedirect implements Navig
                 return;
             switch(requestCode) {
                 case REQUEST_FILE_UNPACK: {
-                    List<PickWhichDialog.Option<Integer>> keyList = new ArrayList<>();
-                    keyList.add(new PickWhichDialog.Option<>("Korea/Japan",0));
-                    keyList.add(new PickWhichDialog.Option<>("Global",1));
-                    new PickWhichDialog<>(context, keyList).setOnOptionPicked(new PickWhichDialog.Option.OnOptionPicked<Integer>() {
+                    DCTools.asyncUnpack(file, context, new OnUnpackFinishedListener() {
                         @Override
-                        public void onOptionPicked(PickWhichDialog.Option<Integer> option) {
-                            if(option != null){
-                                final int key = option.getObject();
-                                DCTools.asyncUnpack(file, key, context, new OnUnpackFinishedListener() {
-                                    @Override
-                                    public void onFinished(DCModel dcModel) {
-                                        if(dcModel != null) {
-                                            if(dcModel.isLoaded()) {
-                                                DCModelsActivity.showPickAction(context, dcModel.asL2DModel());
-                                            }
-                                        }else {
-                                            Toast.makeText(context, "Failed to unpack!", Toast.LENGTH_SHORT).show();
-                                        }
-                                    }
-                                });
+                        public void onFinished(DCModel dcModel) {
+                            if(dcModel != null) {
+                                if(dcModel.isLoaded()) {
+                                    DCModelsActivity.showPickAction(context, dcModel.asL2DModel());
+                                }
+                            }else {
+                                Toast.makeText(context, "Failed to unpack!", Toast.LENGTH_SHORT).show();
                             }
                         }
-                    }).show();
+                    });
                     break;
                 }
                 case REQUEST_FILE_PACK: {
@@ -187,23 +176,15 @@ public class MainActivity extends ActivityWithExceptionRedirect implements Navig
 
     private boolean handleIntent() {
         if(Intent.ACTION_VIEW.equals(getIntent().getAction()) && getIntent().getData() != null) {
-            List<PickWhichDialog.Option<Integer>> keyList = new ArrayList<>();
-            keyList.add(new PickWhichDialog.Option<>("Korea/Japan",0));
-            keyList.add(new PickWhichDialog.Option<>("Global",1));
-            new PickWhichDialog<>(context, keyList).setOnOptionPicked(option -> {
-                if(option != null){
-                    final int key = option.getObject();
-                    DCTools.asyncUnpack(new File(getIntent().getData().getPath()), key, context, dcModel -> {
-                        if(dcModel != null) {
-                            if(dcModel.isLoaded()) {
-                                DCModelsActivity.showPickAction(context, dcModel.asL2DModel());
-                            }
-                        }else {
-                            Toast.makeText(context, "Failed to unpack!", Toast.LENGTH_SHORT).show();
-                        }
-                    });
+            DCTools.asyncUnpack(new File(getIntent().getData().getPath()), context, dcModel -> {
+                if(dcModel != null) {
+                    if(dcModel.isLoaded()) {
+                        DCModelsActivity.showPickAction(context, dcModel.asL2DModel());
+                    }
+                }else {
+                    Toast.makeText(context, "Failed to unpack!", Toast.LENGTH_SHORT).show();
                 }
-            }).show();
+            });
             return true;
         }
         return false;


### PR DESCRIPTION
Removes KR vs Global option prompts and instead tries KR first then falls back to Global if KR fails. Makes for a much easier user experience.